### PR TITLE
Loading the default configuration file when it exists

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 	"flag"
 	"fmt"
 
-	"github.com/gaford/fresh/runner"
+	"github.com/pressly/fresh/runner"
 )
 
 type flagStringSlice []string

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 	"flag"
 	"fmt"
 
-	"github.com/pressly/fresh/runner"
+	"github.com/gaford/fresh/runner"
 )
 
 type flagStringSlice []string

--- a/runner/settings.go
+++ b/runner/settings.go
@@ -82,15 +82,25 @@ var (
 func initSettings(confFile, buildArgs *string, runArgs []string, buildPath, outputBinary, tmpPath *string, watchList, excludeList Multiflag) error {
 	defer buildPaths()
 
+	confFileExists := true
 	if *confFile != "" {
 		if _, err := os.Stat(*confFile); os.IsNotExist(err) {
 			return fmt.Errorf("Config file %s does not exist", *confFile)
 		}
 		settings.ConfigPath = *confFile
+	} else {
+		if _, err := os.Stat(settings.ConfigPath); os.IsNotExist(err) {
+			confFileExists = false
+		}
+	}
 
+	if confFileExists {
 		if _, err := toml.DecodeFile(settings.ConfigPath, &settings); err != nil {
 			return fmt.Errorf("Reading config file failed: %v", err)
 		}
+		runnerLog("Loaded config file: %s", settings.ConfigPath)
+	} else {
+		runnerLog("Loaded default config")
 	}
 
 	if *buildArgs != "" {

--- a/runner/start.go
+++ b/runner/start.go
@@ -82,12 +82,12 @@ func initLogFuncs() {
 func Start(confFile, buildArgs *string, runArgs []string, buildPath, outputBinary, tmpPath *string, watchList, excludeList Multiflag) {
 	os.Setenv("DEV_RUNNER", "1")
 	initLimit()
+	initLogFuncs()
 	err := initSettings(confFile, buildArgs, runArgs, buildPath, outputBinary, tmpPath, watchList, excludeList)
 	if err != nil {
 		logger.Fatalf("Failed to start: %v", err)
 		return
 	}
-	initLogFuncs()
 	initFolders()
 	watch()
 	start()


### PR DESCRIPTION
### Goal  

Load `./runner.conf` if it exists and no other config file specified.

### Reasoning behind PR

Even though this was an intended feature, something had happened where the config file wasn't being loaded if no config file was specified in a flag when `fresh` was called.

---

### Changes

Updates to `runner` package:
- updated `runner/settings.go` to check existence of and load config
from `runner.conf` when no config file is specified via a flag
- add `runnerLog` of which config is loaded at start