### PR TITLE
fix runner.conf file runArgs recognition bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Here is a sample config file with the default settings:
     tmp_path          = "./tmp"
     build_name        = "runner-build"
     build_log         = "runner-build-errors.log"
+    run_args          = []
     valid_ext         = [".go", ".tpl", ".tmpl", ".html"]
     build_delay       = 600
     colors            = 1

--- a/runner.conf.sample
+++ b/runner.conf.sample
@@ -1,6 +1,7 @@
 root              = "."
 watch_paths       = []
 exclude_paths     = []
+run_args          = ["dev"]
 tmp_path          = "./tmp"
 output_binary     = ""
 build_log         = "runner-build-errors.log"

--- a/runner/settings.go
+++ b/runner/settings.go
@@ -106,7 +106,9 @@ func initSettings(confFile, buildArgs *string, runArgs []string, buildPath, outp
 	if *buildArgs != "" {
 		settings.BuildArgs = *buildArgs
 	}
-	settings.RunArgs = []string(runArgs)
+	if len(runArgs) > 0 {
+		settings.RunArgs = runArgs
+	}
 	if *buildPath != "" {
 		settings.Root = *buildPath
 	}


### PR DESCRIPTION
my project use Go web  framework echo, need start it like this: go run main.go dev 
i use fresh to start the project find cannot recognition argArgs in the runner.conf file 

